### PR TITLE
Ensure child NPCs can't accept engagement regardless of roommate romancing settings.

### DIFF
--- a/NPCPatches.cs
+++ b/NPCPatches.cs
@@ -375,6 +375,17 @@ namespace PolyamorySweetLove
         public static bool NPC_engagementResponse_Prefix(NPC __instance, Farmer who, ref bool asRoommate)
         {
             Monitor.Log($"engagement response for {__instance.Name}");
+            
+            if (__instance.Age == NPC.child)
+            {
+                // The NPC is a child, so we want to ensure it can't accept engagement.
+                asRoommate = true;
+                
+                Monitor.Log($"{__instance.Name} is a child NPC. Refusing engagement.");
+                
+                return true;
+            }
+            
             if (asRoommate)
             {
                 Monitor.Log($"{__instance.Name} is roomate");


### PR DESCRIPTION
I noticed the mod otherwise has some good safeguards preventing romancing of child NPCs, but this is one instance where it seems to have been missed. 

I believe this is what resulted in the following post on the Nexus page: ![image](https://github.com/user-attachments/assets/4202f251-c1a1-4af9-82b5-ca2a22453f1b)
