### PR TITLE
Spouse Handling Updates

### DIFF
--- a/HelperEvents.cs
+++ b/HelperEvents.cs
@@ -196,15 +196,16 @@ namespace PolyamorySweetLove
             PorchPlacement = false;
 
 
-            foreach (GameLocation location in Game1.locations)
-            {
-                if (ReferenceEquals(location.GetType(), typeof(FarmHouse)))
-                {
-                    PlaceSpousesInFarmhouse(location as FarmHouse);
-                }
-            }
             if (Game1.IsMasterGame)
             {
+                foreach (GameLocation location in GetAllLocations())
+                {
+                    if (location is FarmHouse fh)
+                    {
+                        PlaceSpousesInFarmhouse(fh);
+                    }
+                }
+
                 Game1.getFarm().addSpouseOutdoorArea(Game1.player.spouse == null ? "" : Game1.player.spouse);
                 farmHelperSpouse = GetRandomSpouse(Game1.MasterPlayer);
             }
@@ -224,12 +225,11 @@ namespace PolyamorySweetLove
             if (!Config.EnableMod)
                 return;
 
-            foreach (GameLocation location in Game1.locations)
+            foreach (GameLocation location in GetAllLocations())
             {
 
-                if (location is FarmHouse)
+                if (location is FarmHouse fh)
                 {
-                    FarmHouse fh = location as FarmHouse;
                     if (fh.owner == null)
                         continue;
 

--- a/Misc.cs
+++ b/Misc.cs
@@ -1395,6 +1395,28 @@ namespace PolyamorySweetLove
             return false;
         }
 
+        /// <summary>
+        /// Get all locations including buildable locations (ie. Cabins)
+        /// </summary>
+        public static IList<GameLocation> GetAllLocations()
+        {
+            IList<GameLocation> locations = new List<GameLocation>(Game1.locations);
+            foreach (GameLocation location in Game1.locations)
+            {
+                if (location.IsBuildableLocation())
+                {
+                    foreach (Building building in location.buildings)
+                    {
+                        if (building.indoors.Value != null)
+                        {
+                            locations.Add(building.indoors.Value);
+                        }
+                    }
+                }
+            }
+            return locations;
+        }
+
 
     }
 }

--- a/Misc.cs
+++ b/Misc.cs
@@ -771,7 +771,7 @@ namespace PolyamorySweetLove
                 {
                     Game1.warpCharacter(spouse, farmer.homeLocation.Value, farmHouse.getSpouseBedSpot(spouse.Name));
                     SMonitor.Log("PSL - Warping "+spouse.Name+"to farmhouse because NPC was someother strange place.");
-                    spouse.modData.Add("SpouseNeedsPlaced", "");
+                    spouse.modData["SpouseNeedsPlaced"] = "";
                 }
 
                 //GenericDialogue

--- a/Misc.cs
+++ b/Misc.cs
@@ -144,7 +144,8 @@ namespace PolyamorySweetLove
 
                 if (!farmHouse.Equals(spouse.currentLocation))
                 {
-                    Game1.warpCharacter(spouse, "FarmHouse", getRandomOpenPointInFarmHouse(myRand, 0, 60));
+                    Point position = farmHouse.getRandomOpenPointInHouse(myRand);
+                    Game1.warpCharacter(spouse, farmHouse, new Vector2(position.X, position.Y));
                     spouse.faceDirection(myRand.Next(0, 4));
                     SMonitor.Log("PSL - Warping NPC from where ever to Random Open Place for begin placement - " + spouse.Name);
                 }

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -145,6 +145,7 @@ namespace PolyamorySweetLove
             harmony.Patch(
                original: AccessTools.Method(typeof(NPC), nameof(NPC.tryToReceiveActiveObject)),
                prefix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_tryToReceiveActiveObject_Prefix)),
+               postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_tryToReceiveActiveObject_Postfix)),
                transpiler: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_tryToReceiveActiveObject_Transpiler))
             );
 

--- a/NPCPatches.cs
+++ b/NPCPatches.cs
@@ -613,7 +613,7 @@ namespace PolyamorySweetLove
         }
           */
 
-        public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, ref Farmer who, Dictionary<string, string> ___dialogue, ref string __state)
+        public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, ref Farmer who, bool probe, Dictionary<string, string> ___dialogue, ref bool __result, ref string __state)
         {
             try
             {
@@ -636,7 +636,7 @@ namespace PolyamorySweetLove
                     Game1.drawObjectDialogue(Game1.parseText(Game1.content.LoadString("Strings\\Characters:MovieInvite_NoTheater", __instance.displayName)));
                     return false;
                 }
-                else if (who.ActiveObject.ParentSheetIndex == 808 && __instance.Name.Equals("Krobus") && ModEntry.Button)
+                else if (who.ActiveObject.ParentSheetIndex == 808 && __instance.Name.Equals("Krobus") && !probe)
                 {
                     if (who.getFriendshipHeartLevelForNPC(__instance.Name) >= 10 && who.HouseUpgradeLevel >= 1)
                     {
@@ -644,7 +644,7 @@ namespace PolyamorySweetLove
                         return false;
                     }
                 }
-                else if (who.ActiveObject.ParentSheetIndex == 458 && ModEntry.Button)
+                else if (who.ActiveObject.ParentSheetIndex == 458 && !probe)
                 {
                     Monitor.Log($"Try give bouquet to {__instance.Name}");
 
@@ -777,7 +777,7 @@ namespace PolyamorySweetLove
                         return false;
                     }
                 }
-                else if (who.ActiveObject.ParentSheetIndex == 460 && ModEntry.Button)
+                else if (who.ActiveObject.ParentSheetIndex == 460 && !probe)
                 {
                     //RejectMermaidPendant_Divorced
                     //RejectMermaidPendant_NeedHouseUpgrade
@@ -935,7 +935,7 @@ namespace PolyamorySweetLove
                         return false;
                     }
                 }
-                else if (who.ActiveObject.ParentSheetIndex == 809 && !who.ActiveObject.bigCraftable.Value && ModEntry.Button)
+                else if (who.ActiveObject.ParentSheetIndex == 809 && !who.ActiveObject.bigCraftable.Value && !probe)
                 {
 
                     Monitor.Log($"Tried to give movie ticket to {__instance.Name}");
@@ -983,9 +983,9 @@ namespace PolyamorySweetLove
                     return true;
                 }
 
-                else if (who.ActiveItem.Name.Equals("Áine Flower") && ModEntry.Button)
+                else if (who.ActiveItem.Name.Equals("Áine Flower") && !probe)
                 {
-                    //if (ModEntry.Button == true)
+                    //if (!probe)
                     {
 
 
@@ -1060,7 +1060,7 @@ namespace PolyamorySweetLove
 
 
                     }
-                     if ( ModEntry.Button)
+                     if ( !probe)
                     {
 
                         if (__instance.Name.Equals("Abigail"))
@@ -1100,7 +1100,7 @@ namespace PolyamorySweetLove
 
                 }
 
-                else if (who.ActiveItem.Name.Equals("Aphrodite Flower") && ModEntry.Button)
+                else if (who.ActiveItem.Name.Equals("Aphrodite Flower") && !probe)
                 {
                     if (ModEntry.AphroditeFlowerGiven == false)
                     {

--- a/NPCPatches.cs
+++ b/NPCPatches.cs
@@ -613,7 +613,7 @@ namespace PolyamorySweetLove
         }
           */
 
-        public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, ref Farmer who, Dictionary<string, string> ___dialogue)
+        public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, ref Farmer who, Dictionary<string, string> ___dialogue, ref string __state)
         {
             try
             {
@@ -1165,7 +1165,37 @@ namespace PolyamorySweetLove
             {
                 Monitor.Log($"PSL - Failed in {nameof(NPC_tryToReceiveActiveObject_Prefix)}:\n{ex}", LogLevel.Error);
             }
+
+            try
+            {
+                // Temporarily change primary spouse. This is largely to bypass the 2-gift weekly limit that affects non-primary spouses
+                if (ModEntry.GetSpouses(Game1.player, false).ContainsKey(__instance.Name))
+                {
+                    __state = Game1.player.spouse;
+                    Game1.player.spouse = __instance.Name;
+                }
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(NPC_tryToReceiveActiveObject_Prefix)}:\n{ex}", LogLevel.Error);
+            }
+
             return true;
+        }
+
+        public static void NPC_tryToReceiveActiveObject_Postfix(string __state)
+        {
+            try
+            {
+                if (__state != null)
+                {
+                    Game1.player.spouse = __state;
+                }
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(NPC_tryToReceiveActiveObject_Postfix)}:\n{ex}", LogLevel.Error);
+            }
         }
 
         public static IEnumerable<CodeInstruction> NPC_tryToReceiveActiveObject_Transpiler(IEnumerable<CodeInstruction> instructions)

--- a/Pregnancy.cs
+++ b/Pregnancy.cs
@@ -376,12 +376,13 @@ namespace PolyamorySweetLove
                         ___babyName
                         }));
                     }
+                    string spouseName = lastBirthingSpouse.Name;
                     Game1.morningQueue.Enqueue(delegate
                     {
                         mp.globalChatInfoMessage("Baby", new string[]
                         {
                         Lexicon.capitalize(Game1.player.Name),
-                        Game1.player.spouse,
+                            spouseName,
                         Lexicon.getGenderedChildTerm(___isMale),
                         Lexicon.getPronoun(___isMale),
                         baby.displayName


### PR DESCRIPTION
Another assortment of updates. Would you prefer if I make many small pull requests, or mid-sized collections like this? Asking since I'm planning to make a lot more updates.

What's in this PR (each change is in its own commit):
1. Don't think you are using it for anything at the moment, but `modData.Add("SpouseNeedsPlaced", "")` throws an exception if the entry is already present. I ran into this when Elliott was away for his 14-heart event, so this code ran every day. That's something to keep in-mind depending on your plans for that flag.
2. Game1.locations does not include buildable locations, such as farmhand cabins. This caused some of the code to miss handling spouses for non-host players. An example was the code that sends the spouses to bed and disables their collision. There's also a change to the day-started code to make it so only the MasterGame will handle spouse placement. In multiplayer, every client was placing all spouses at the beginning of the day, which lead to weird things sometimes.
3. This was a kind of lazy change, but it's what I did when I made the same change back for FreeLove (never pushed it upstream). This just temporarily changes the primary spouse to the spouse you're attempting to give a gift to. This allows you to give more than 2 gifts to non-primary spouses each week.
4. In multiplayer, there is an announcement when a baby is born that contains the player and spouse names. The spouse name in the message was always set to the primary spouse. This change corrects that be the birthing spouse.
5. There is some code that checks that a spouse is in the farmhouse at the beginning of the day and warps them to the farmhouse if they are not there. In the context of a farmhand cabin, this code was correctly identifying that a spouse was not home, but was warping them to the main player's farmhouse instead of the cabin that they belong to.
6. This one is just a general update. Stardew 1.6 added a "probe" parameter to the tryReceiveActiveObject method. If probe is true, the method is expected to return true or false indicating if the NPC would react to the object. If probe is false, then the player is actually giving the object to the NPC and the code should actually apply changes as a result. I noticed that you were using ModEntry.Button for the same purpose. I changed all of these usages to !probe, so you don't have to worry about checking for the proper keypresses. I plan to update the usage of ModEntry.Button in the Lilith Token handling code as well. That will probably involve moving that code to NPC.tryReceiveActiveObject since a Child is an NPC, and we'll get access to the probe flag again.