### PR TITLE
Some Major Changes

### DIFF
--- a/FarmerPatches.cs
+++ b/FarmerPatches.cs
@@ -2,6 +2,7 @@
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Characters;
+using StardewValley.Extensions;
 using StardewValley.Menus;
 using System;
 using System.Collections.Generic;
@@ -95,7 +96,7 @@ namespace PolyamorySweetLove
         {
             try
             {
-                __result = __instance.team.IsMarried(__instance.UniqueMultiplayerID) || ModEntry.GetSpouses(__instance, true).Count > 0;
+                __result = __instance.team.IsMarried(__instance.UniqueMultiplayerID) || ModEntry.GetSpouses(__instance, false).Count > 0;
                 return false;
             }
             catch (Exception ex)
@@ -253,6 +254,60 @@ namespace PolyamorySweetLove
                 Monitor.Log($"Failed in {nameof(Farmer_getChildren_Prefix)}:\n{ex}", LogLevel.Error);
             }
             return true;
+        }
+
+        public static bool Farmer_GetDaysMarried_Prefix(Farmer __instance, ref int  __result)
+        {
+            try
+            {
+                if (ModEntry.tempOfficialSpouse != null && __instance.friendshipData.ContainsKey(ModEntry.tempOfficialSpouse.Name) && __instance.friendshipData[ModEntry.tempOfficialSpouse.Name].IsMarried())
+                {
+                    __result = __instance.friendshipData[ModEntry.tempOfficialSpouse.Name].DaysMarried;
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(Farmer_GetDaysMarried_Prefix)}:\n{ex}", LogLevel.Error);
+            }
+            return true;
+        }
+
+        public static bool Farmer_getChildrenCount_Prefix(Farmer __instance, ref int __result)
+        {
+            try
+            {
+                if (ModEntry.tempOfficialSpouse != null)
+                {
+                    __result = Utility.getHomeOfFarmer(__instance).getChildren().FindAll(c => (c.modData.TryGetValue("ApryllForever.PolyamorySweetLove/OtherParent", out string parent) && parent == ModEntry.tempOfficialSpouse.Name)).Count;
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(Farmer_getChildrenCount_Prefix)}:\n{ex}", LogLevel.Error);
+            }
+            return true;
+        }
+
+        public static void Utility_CreateDaySaveRandom_Postfix(ref Random __result)
+        {
+            try
+            {
+                if (ModEntry.tempOfficialSpouse != null)
+                {
+                    Farmer farmer = ModEntry.tempOfficialSpouse.getSpouse();
+                    List<string> spouses = ModEntry.GetSpouses(farmer, true).Keys.ToList();
+                    spouses.Sort();
+                    int index = spouses.IndexOf(ModEntry.tempOfficialSpouse.Name);
+                    for (int i = 0; i < index; i++)
+                        __result.NextBool();
+                }
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(Utility_CreateDaySaveRandom_Postfix)}:\n{ex}", LogLevel.Error);
+            }
         }
     }
 }

--- a/Game1Patches.cs
+++ b/Game1Patches.cs
@@ -19,5 +19,10 @@ namespace PolyamorySweetLove
             if (EventPatches.startingLoadActors)
                 lastGotCharacter = name;
         }
+
+        public static void getAvailableWeddingEvent_Postfix(Event __result)
+        {
+            ModEntry.WeddingToday = __result;
+        }
     }
 }

--- a/HelperEvents.cs
+++ b/HelperEvents.cs
@@ -188,33 +188,41 @@ namespace PolyamorySweetLove
         public static void GameLoop_DayStarted(object sender, DayStartedEventArgs e)
         {
             ResetDivorces();
-            ResetSpouses(Game1.player);
+
+            foreach (Farmer f in Game1.getAllFarmers())
+            {
+                ResetSpouses(f, true);
+                var spouses = GetSpouses(f, false).Keys;
+                foreach (string s in spouses)
+                {
+                    SMonitor.Log($"{f.Name} is married to {s}");
+                }
+            }
+            
             BabyTonight = false;
             BabyTonightSpouse = String.Empty;
             AphroditeFlowerGiven = false;
             PatioPlacement = false;
             PorchPlacement = false;
 
+            FixSpouseSpawnLocations();
+        }
 
-            if (Game1.IsMasterGame)
+        public static void GameLoop_DayEnding(object sender, DayEndingEventArgs e)
+        {
+            // Encountered a situation where my primary spouse got changed from my engaged spouse
+            // That is a problem as that will stop the wedding from occurring
+            // Since I'm unsure what caused it, I'm slapping a band-aid check here
+            foreach (Farmer farmer in Game1.getAllFarmers())
             {
-                foreach (GameLocation location in GetAllLocations())
+                foreach (string npc in farmer.friendshipData.Keys)
                 {
-                    if (location is FarmHouse fh)
+                    if (farmer.friendshipData[npc].IsEngaged())
                     {
-                        PlaceSpousesInFarmhouse(fh);
+                        SMonitor.Log($"Setting primary spouse for {farmer} to engaged NPC {npc} (was {farmer.spouse})");
+                        farmer.spouse = npc;
+                        break;
                     }
-                }
-
-                Game1.getFarm().addSpouseOutdoorArea(Game1.player.spouse == null ? "" : Game1.player.spouse);
-                farmHelperSpouse = GetRandomSpouse(Game1.MasterPlayer);
-            }
-            foreach (Farmer f in Game1.getAllFarmers())
-            {
-                var spouses = GetSpouses(f, true).Keys;
-                foreach (string s in spouses)
-                {
-                    SMonitor.Log($"{f.Name} is married to {s}");
                 }
             }
         }
@@ -233,7 +241,7 @@ namespace PolyamorySweetLove
                     if (fh.owner == null)
                         continue;
 
-                    List<string> allSpouses = GetSpouses(fh.owner, true).Keys.ToList();
+                    List<string> allSpouses = GetSpouses(fh.owner, false).Keys.ToList();
                     List<string> bedSpouses = ReorderSpousesForSleeping(allSpouses.FindAll((s) => Config.RoommateRomance || !fh.owner.friendshipData[s].RoommateMarriage));
 
                     using (IEnumerator<NPC> characters = fh.characters.GetEnumerator())

--- a/LocationPatches.cs
+++ b/LocationPatches.cs
@@ -50,7 +50,7 @@ namespace PolyamorySweetLove
             {
                 if (spouseName == null || !Config.EnableMod)
                     return true;
-                var spouses = ModEntry.GetSpouses(__instance.owner, true);
+                var spouses = ModEntry.GetSpouses(__instance.owner, false);
 
                 if (!spouses.TryGetValue(spouseName, out NPC spouse) || spouse is null || spouse.isMoving() || !ModEntry.IsInBed(__instance, spouse.GetBoundingBox()))
                     return true;

--- a/Misc.cs
+++ b/Misc.cs
@@ -20,6 +20,7 @@ namespace PolyamorySweetLove
     public partial class ModEntry
     {
         private static Dictionary<string, int> topOfHeadOffsets = new Dictionary<string, int>();
+        public static Event WeddingToday = null;
 
         public static void ReloadSpouses(Farmer farmer)
         {
@@ -37,7 +38,7 @@ namespace PolyamorySweetLove
             SMonitor.Log($"Checking for extra spouses in {farmer.friendshipData.Count()} friends");
             foreach (string friend in farmer.friendshipData.Keys)
             {
-                if (farmer.friendshipData[friend].IsMarried() && friend != farmer.spouse)
+                if (farmer.friendshipData[friend].IsMarried())
                 {
                     var npc = Game1.getCharacterFromName(friend, true);
                     if (npc != null)
@@ -99,17 +100,6 @@ namespace PolyamorySweetLove
         }
         public static void PlaceSpousesInFarmhouse(FarmHouse farmHouse)
         {
-            //string shakeTimer = Helper.Reflection.GetField<string>(__instance, "shakeTimer").GetValue();
-            //farmHouse = Game1.RequireLocation<FarmHouse>(Game1.player.homeLocation.Value);
-            //if (SortSpouseOrder == true)
-            {
-                //spousesortigncodehere
-
-
-
-            }
-
-
             Point porchspot = farmHouse.getPorchStandingSpot();
             Point kitchenspot = farmHouse.getKitchenStandingSpot();
             Point bedspot = farmHouse.getBedSpot();
@@ -1059,6 +1049,94 @@ namespace PolyamorySweetLove
         }*/
         }
 
+        public static void FixSpouseSpawnLocations()
+        {
+            if (!Game1.IsMasterGame)
+                return;
+
+            if (NPCPatches.PatioSpouse != null)
+            {
+                // Wrong patio might have been loaded. Load the correct one and move spouse to correct location for that patio
+                SMonitor.Log($"Patio spouse is {NPCPatches.PatioSpouse.Name}");
+                Game1.getFarm().addSpouseOutdoorArea(NPCPatches.PatioSpouse.Name);
+                NPCPatches.PatioSpouse.setTilePosition(Game1.getFarm().spousePatioSpot);
+                NPCPatches.PatioSpouse = null;
+            }
+
+            Farmer gettingMarriedFarmer = null;
+            string gettingMarriedNPC = null;
+            if (WeddingToday != null)
+            {
+                gettingMarriedFarmer = WeddingToday.farmer;
+                gettingMarriedNPC = gettingMarriedFarmer?.spouse;
+                WeddingToday = null;
+            }
+
+            foreach (GameLocation location in GetAllLocations())
+            {
+                if (location is FarmHouse farmhouse)
+                {
+                    Farmer farmer = farmhouse.owner;
+                    if (farmer == null)
+                        continue;
+
+                    SMonitor.Log($"Checking farmhouse for {farmer.Name}");
+                    Random random = Utility.CreateDaySaveRandom(farmer.UniqueMultiplayerID);
+                    List<NPC> spouses = GetSpouses(farmer, false).Values.ToList();
+                    ShuffleList(ref spouses, random);
+                    foreach (NPC spouse in spouses)
+                    {
+                        if (gettingMarriedFarmer == farmer && gettingMarriedNPC == spouse.Name)
+                        {
+                            SMonitor.Log($"It is {spouse.Name}'s wedding day, staying on porch");
+                        }
+                        else if (gettingMarriedFarmer == farmer && gettingMarriedNPC != null && spouse.Name != gettingMarriedNPC && spouse.currentLocation == Game1.getFarm() && spouse.TilePoint == farmhouse.getPorchStandingSpot())
+                        {
+                            // If current farmer is getting married today, no other spouse can be on the porch
+                            SMonitor.Log($"{spouse.Name} is on the porch on {gettingMarriedNPC}'s wedding day");
+                            Point newPoint = farmhouse.getRandomOpenPointInHouse(random, tries: 100);
+                            if (newPoint != Point.Zero)
+                            {
+                                SMonitor.Log($"Moving {spouse.Name} to {newPoint}");
+                                Game1.warpCharacter(spouse, farmer.homeLocation.Value, newPoint);
+                                spouse.faceDirection(random.Next(4));
+                            }
+                        }
+                        else if (IsInBed(farmhouse, spouse.GetBoundingBox()))
+                        {
+                            // Game code would have placed all bed spouses in the same place. Move them to their spot
+                            Point bedSpot = ModEntry.GetSpouseBedEndPoint(farmhouse, spouse.Name);
+                            SMonitor.Log($"{spouse.Name} is in bed. Moving to {bedSpot}");
+                            spouse.setTilePosition(bedSpot);
+                        }
+                        else
+                        {
+                            // Check if any other spouses are on the same tile
+                            foreach (NPC other in spouses)
+                            {
+                                if (spouse == other)
+                                    continue;
+                                if (spouse.currentLocation == other.currentLocation && spouse.Tile == other.Tile)
+                                {
+                                    SMonitor.Log($"{spouse.Name} is at the same position as {other.Name}");
+                                    Point newPoint = farmhouse.getRandomOpenPointInHouse(random, tries:100);
+                                    if (newPoint != Point.Zero)
+                                    {
+                                        SMonitor.Log($"Moving {other.Name} to {newPoint}");
+                                        if (other.currentLocation == farmhouse)
+                                            other.setTilePosition(newPoint);
+                                        else
+                                            Game1.warpCharacter(other, farmer.homeLocation.Value, newPoint);
+                                        other.faceDirection(random.Next(4));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         private static bool IsTileOccupied(GameLocation location, Point tileLocation, string characterToIgnore)
         {
             Rectangle tileLocationRect = new Rectangle(tileLocation.X * 64 + 1, tileLocation.Y * 64 + 1, 62, 62);
@@ -1400,13 +1478,16 @@ namespace PolyamorySweetLove
             }
         }
 
-        public static void ShuffleList<T>(ref List<T> list)
+        public static void ShuffleList<T>(ref List<T> list, Random random = null)
         {
+            if (random == null)
+                random = myRand;
+
             int n = list.Count;
             while (n > 1)
             {
                 n--;
-                int k = myRand.Next(n + 1);
+                int k = random.Next(n + 1);
                 var value = list[k];
                 list[k] = list[n];
                 list[n] = value;

--- a/Misc.cs
+++ b/Misc.cs
@@ -51,6 +51,13 @@ namespace PolyamorySweetLove
                 farmer.spouse = currentSpouses[farmer.UniqueMultiplayerID].First().Key;
             SMonitor.Log($"reloaded {currentSpouses[farmer.UniqueMultiplayerID].Count} spouses for {farmer.Name} {farmer.UniqueMultiplayerID}");
         }
+
+        /// <summary>
+        /// Gets all spouses (and engaged npcs) for the farmer
+        /// </summary>
+        /// <param name="farmer"></param>
+        /// <param name="all">true returns all spouses + engaged npc if any. false returns only spouses.</param>
+        /// <returns></returns>
         public static Dictionary<string, NPC> GetSpouses(Farmer farmer, bool all)
         {
             if (!currentSpouses.ContainsKey(farmer.UniqueMultiplayerID) || ((currentSpouses[farmer.UniqueMultiplayerID].Count == 0 && farmer.spouse != null)))
@@ -84,7 +91,7 @@ namespace PolyamorySweetLove
 
         public static string GetRandomSpouse(Farmer f)
         {
-            var spouses = GetSpouses(f, true);
+            var spouses = GetSpouses(f, false);
             if (spouses.Count == 0)
                 return null;
             ShuffleDic(ref spouses);
@@ -114,7 +121,7 @@ namespace PolyamorySweetLove
             if (farmer == null)
                 return;
 
-            List<NPC> allSpouses = GetSpouses(farmer, true).Values.ToList();
+            List<NPC> allSpouses = GetSpouses(farmer, false).Values.ToList();
 
             if (allSpouses.Count == 0)
             {
@@ -1123,9 +1130,9 @@ namespace PolyamorySweetLove
         public static List<string> GetBedSpouses(FarmHouse fh)
         {
             if (Config.RoommateRomance)
-                return GetSpouses(fh.owner, true).Keys.ToList();
+                return GetSpouses(fh.owner, false).Keys.ToList();
 
-            return GetSpouses(fh.owner, true).Keys.ToList().FindAll(s => !fh.owner.friendshipData[s].RoommateMarriage);
+            return GetSpouses(fh.owner, false).Keys.ToList().FindAll(s => !fh.owner.friendshipData[s].RoommateMarriage);
         }
 
         public static List<string> ReorderSpousesForSleeping(List<string> sleepSpouses)

--- a/ModEntry.cs
+++ b/ModEntry.cs
@@ -85,6 +85,7 @@ namespace PolyamorySweetLove
             helper.Events.GameLoop.GameLaunched += GameLoop_GameLaunched;
             helper.Events.GameLoop.SaveLoaded += GameLoop_SaveLoaded;
             helper.Events.GameLoop.DayStarted += GameLoop_DayStarted;
+            helper.Events.GameLoop.DayEnding += GameLoop_DayEnding;
             helper.Events.GameLoop.OneSecondUpdateTicked += GameLoop_OneSecondUpdateTicked;
 
             helper.Events.Content.AssetRequested += Content_AssetRequested;
@@ -115,7 +116,14 @@ namespace PolyamorySweetLove
 
             harmony.Patch(
                original: AccessTools.Method(typeof(NPC), nameof(NPC.marriageDuties)),
-               postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_marriageDuties_Postfix))
+               prefix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_marriageDuties_Prefix)),
+               postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_marriageDuties_Postfix)),
+               transpiler: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_marriageDuties_Transpiler))
+            );
+
+            harmony.Patch(
+               original: AccessTools.Method(typeof(NPC), nameof(NPC.setUpForOutdoorPatioActivity)),
+               postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_setUpForOutdoorPatioActivity_Postfix))
             );
 
             harmony.Patch(
@@ -151,16 +159,16 @@ namespace PolyamorySweetLove
                postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_engagementResponse_Postfix))
             );
 
-            harmony.Patch(
-               original: AccessTools.Method(typeof(NPC), nameof(NPC.spouseObstacleCheck)),
-               prefix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_spouseObstacleCheck_Prefix))
-            );
+            //harmony.Patch(
+            //   original: AccessTools.Method(typeof(NPC), nameof(NPC.spouseObstacleCheck)),
+            //   prefix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_spouseObstacleCheck_Prefix))
+            //);
 
-            harmony.Patch(
-               original: AccessTools.Method(typeof(NPC), nameof(NPC.playSleepingAnimation)),
-               prefix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_playSleepingAnimation_Prefix)),
-               postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_playSleepingAnimation_Postfix))
-            );
+            //harmony.Patch(
+            //   original: AccessTools.Method(typeof(NPC), nameof(NPC.playSleepingAnimation)),
+            //   prefix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_playSleepingAnimation_Prefix)),
+            //   postfix: new HarmonyMethod(typeof(NPCPatches), nameof(NPCPatches.NPC_playSleepingAnimation_Postfix))
+            //);
 
             harmony.Patch(
                original: AccessTools.Method(typeof(NPC), nameof(NPC.GetDispositionModifiedString)),
@@ -318,6 +326,22 @@ namespace PolyamorySweetLove
                prefix: new HarmonyMethod(typeof(FarmerPatches), nameof(FarmerPatches.Farmer_getChildren_Prefix))
             );
 
+            harmony.Patch(
+               original: AccessTools.Method(typeof(Farmer), nameof(Farmer.GetDaysMarried)),
+               prefix: new HarmonyMethod(typeof(FarmerPatches), nameof(FarmerPatches.Farmer_GetDaysMarried_Prefix))
+            );
+
+            harmony.Patch(
+               original: AccessTools.Method(typeof(Farmer), nameof(Farmer.getChildrenCount)),
+               prefix: new HarmonyMethod(typeof(FarmerPatches), nameof(FarmerPatches.Farmer_getChildrenCount_Prefix))
+            );
+
+            // Utility Patches
+            harmony.Patch(
+               original: AccessTools.Method(typeof(Utility), nameof(Utility.CreateDaySaveRandom)),
+               postfix: new HarmonyMethod(typeof(FarmerPatches), nameof(FarmerPatches.Utility_CreateDaySaveRandom_Postfix))
+            );
+
 
             // UI patches
 
@@ -362,6 +386,12 @@ namespace PolyamorySweetLove
                original: AccessTools.GetDeclaredMethods(typeof(Game1)).Where(m => m.Name == "getCharacterFromName" && m.ReturnType == typeof(NPC)).First(),
                prefix: new HarmonyMethod(typeof(Game1Patches), nameof(Game1Patches.getCharacterFromName_Prefix))
             );
+
+            harmony.Patch(
+               original: AccessTools.Method(typeof(Game1), nameof(Game1.getAvailableWeddingEvent)),
+               postfix: new HarmonyMethod(typeof(Game1Patches), nameof(Game1Patches.getAvailableWeddingEvent_Postfix))
+            );
+
             //Child Patch
             harmony.Patch(
              original: AccessTools.DeclaredMethod(typeof(Child), nameof(Child.checkAction)),

--- a/NPCPatches.cs
+++ b/NPCPatches.cs
@@ -1099,7 +1099,7 @@ namespace PolyamorySweetLove
                         }
                         if (__instance.IsVillager)
                         {
-                            if (ModEntry.GetSpouses(who, true).ContainsKey(__instance.Name))
+                            if (ModEntry.GetSpouses(who, false).ContainsKey(__instance.Name))
                             {
                                 who.changeFriendship(25, __instance);
                                 who.reduceActiveItemByOne();

--- a/NPCPatches.cs
+++ b/NPCPatches.cs
@@ -25,6 +25,7 @@ namespace PolyamorySweetLove
         private static IMonitor Monitor;
         private static ModConfig Config;
         private static IModHelper Helper;
+        public static NPC PatioSpouse = null;
 
         // call this method from your Entry class
         public static void Initialize(IMonitor monitor, ModConfig config, IModHelper helper)
@@ -241,38 +242,277 @@ namespace PolyamorySweetLove
             }
         }
 
-        /*
-        public static bool NPC_marriageDuties_Prefix()
-        {
-            if(!Config.EnableMod)
-            {
-                return true;
-            }
-            return true;
-        } */
-
-
         public static void NPC_marriageDuties_Postfix(NPC __instance)
         {
-
-
-
-
-
-
             try
             {
                 if (ModEntry.tempOfficialSpouse == __instance)
                 {
                     ModEntry.tempOfficialSpouse = null;
                 }
-                return; 
-                
+                return;
+
             }
             catch (Exception ex)
             {
                 Monitor.Log($"Failed in fucking with temp spouse setting in {nameof(NPC_marriageDuties_Postfix)}:\n{ex}", LogLevel.Error);
             }
+        }
+
+        public static IEnumerable<CodeInstruction> NPC_marriageDuties_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator)
+        {
+            // Splitting this transpiler into 3 functions, 1 for each task
+
+            List<CodeInstruction> instructionsList = new(instructions);
+            marriageDuties_OnePatioSpouse(instructionsList, generator);
+            marriageDuties_WinterPatio(instructionsList, generator);
+            marriageDuties_AboutToGiveBirthDialogue(instructionsList, generator);
+
+            return instructionsList.AsEnumerable();
+        }
+
+        public static void marriageDuties_OnePatioSpouse(List<CodeInstruction> instructionsList, ILGenerator generator)
+        {
+            /*
+                Code this is modifying:
+                if (!Game1.isRaining && !Game1.IsWinter && Game1.shortDayNameFromDayOfSeason(Game1.dayOfMonth).Equals("Sat") && spouse == Game1.MasterPlayer && !base.Name.Equals("Krobus"))
+                {
+                    setUpForOutdoorPatioActivity();
+                    return;
+                }
+                
+                Changing to approximately this:
+                if (!Game1.isRaining && !Game1.IsWinter && Game1.shortDayNameFromDayOfSeason(Game1.dayOfMonth).Equals("Sat") && spouse == Game1.MasterPlayer && !base.Name.Equals("Krobus") && NPCPatches.PatioSpouse == null)
+                {
+                    setUpForOutdoorPatioActivity();
+                    return;
+                }
+
+                IL Code looks like this. I'm searching for IL_0404 and IL_0405, and adding a branch before them to skip the call if PatioSpouse is set.
+
+                IL_03c6: ldsfld bool StardewValley.Game1::isRaining
+		        IL_03cb: brtrue.s IL_040b
+
+		        IL_03cd: call bool StardewValley.Game1::get_IsWinter()
+		        IL_03d2: brtrue.s IL_040b
+
+                IL_03d4: ldsfld int32 StardewValley.Game1::dayOfMonth
+		        IL_03d9: call string StardewValley.Game1::shortDayNameFromDayOfSeason(int32)
+		        IL_03de: ldstr "Sat"
+		        IL_03e3: callvirt instance bool [System.Runtime]System.String::Equals(string)
+		        IL_03e8: brfalse.s IL_040b
+
+		        IL_03ea: ldloc.0
+		        IL_03eb: call class StardewValley.Farmer StardewValley.Game1::get_MasterPlayer()
+		        IL_03f0: bne.un.s IL_040b
+
+		        // this.setUpForOutdoorPatioActivity();
+		        IL_03f2: ldarg.0
+		        IL_03f3: call instance string StardewValley.Character::get_Name()
+		        IL_03f8: ldstr "Krobus"
+		        IL_03fd: callvirt instance bool [System.Runtime]System.String::Equals(string)
+		        IL_0402: brtrue.s IL_040b
+
+		        IL_0404: ldarg.0
+		        IL_0405: call instance void StardewValley.NPC::setUpForOutdoorPatioActivity()
+		        // int num = 12;
+		        IL_040a: ret
+            */
+            MethodInfo patioMethod = AccessTools.Method(typeof(NPC), nameof(NPC.setUpForOutdoorPatioActivity));
+            FieldInfo? patioSpouseField = typeof(NPCPatches).GetField(nameof(PatioSpouse));
+            int insertIndex = -1;
+            System.Reflection.Emit.Label? branchLabel = null;
+
+            // Find the setUpForOutdoorPatioActivity() call
+            for (int i = 0; i < instructionsList.Count - 1; i++)
+            {
+                var first = instructionsList[i];
+                var second = instructionsList[i + 1];
+
+                if (first.IsLdarg(0) && second.Calls(patioMethod))  // "ldarg.0" and "call instance void StardewValley.NPC::setUpForOutdoorPatioActivity()"
+                {
+                    insertIndex = i;
+                    break;
+                }
+
+                if (first.Branches(out System.Reflection.Emit.Label? label))  // Keeping track of the last brtrue.s destination
+                    branchLabel = label;
+            }
+
+            if (insertIndex >= 0 && branchLabel.HasValue && patioSpouseField != null)
+            {
+                // Insert a "branch if PatioSpouse is not null"
+                List<CodeInstruction> newInstructions = new()
+                {
+                    new CodeInstruction(OpCodes.Ldsfld, patioSpouseField),  // Load PatioSpouse onto stack
+                    new CodeInstruction(OpCodes.Brtrue, branchLabel)  // Branch to branchLabel if PatioSpouse != null
+                };
+                instructionsList.InsertRange(insertIndex, newInstructions);
+            }
+            else
+                Monitor.Log($"Could not apply patio spouse patch in {nameof(NPC_marriageDuties_Transpiler)}", LogLevel.Warn);
+        }
+
+        public static bool WinterPatio()
+        {
+            return Config.WinterPatio;
+        }
+        
+        public static void marriageDuties_WinterPatio(List<CodeInstruction> instructionsList, ILGenerator generator)
+        {
+            MethodInfo isWinter = AccessTools.PropertyGetter(typeof(Game1), nameof(Game1.IsWinter));
+            MethodInfo configWinterPatio = SymbolExtensions.GetMethodInfo(() => WinterPatio());
+            bool applied = false;
+            for (int i = 0; i < instructionsList.Count - 1; i++)
+            {
+                // Searching for
+                // IL_03cd: call bool StardewValley.Game1::get_IsWinter()
+                // IL_03d2: brtrue.s IL_040b
+                var first = instructionsList[i];
+                var second = instructionsList[i + 1];
+
+                if (first.Calls(isWinter) && second.Branches(out System.Reflection.Emit.Label? _))
+                {
+                    System.Reflection.Emit.Label label = generator.DefineLabel();
+                    instructionsList[i + 2].labels.Add(label);  // Add new branching label to instruction following the isWinter check
+
+                    instructionsList.InsertRange(i, new List<CodeInstruction>()
+                    {
+                        new CodeInstruction(OpCodes.Call, configWinterPatio),  // Get value from Config.WinterPatio
+                        new CodeInstruction(OpCodes.Brtrue, label)  // Branch if value is true (skipping the isWinter check)
+                    });
+                    applied = true;
+                    break;
+                }
+            }
+
+            if (!applied)
+                Monitor.Log($"Could not apply winter patio patch in {nameof(NPC_marriageDuties_Transpiler)}", LogLevel.Warn);
+        }
+
+        public static void marriageDuties_AboutToGiveBirthDialogue(List<CodeInstruction> instructionsList, ILGenerator generator)
+        {
+            /*
+            IL_0772: ldarg.0
+	        IL_0773: call instance bool StardewValley.NPC::isAdoptionSpouse()
+	        IL_0778: brfalse IL_080c
+            */
+            MethodInfo isAdoptionSpouse = AccessTools.Method(typeof(NPC), nameof(NPC.isAdoptionSpouse));
+            //MethodInfo configGayPregnancies = SymbolExtensions.GetMethodInfo(() => Config.GayPregnancies);
+            MethodInfo createRandom = AccessTools.Method(typeof(Utility), nameof(Utility.CreateDaySaveRandom));
+            MethodInfo hookFunction = AccessTools.Method(typeof(NPCPatches), nameof(NPCPatches.marriageDuties_AboutToGiveBirthDialogue_hook));
+            object localVariableIndexRandom = null;
+            for (int i = 0; i < instructionsList.Count - 1; i++)
+            {
+                var first = instructionsList[i];
+                var second = instructionsList[i + 1];
+
+                if (first.Calls(createRandom) && second.IsStloc())
+                {
+                    localVariableIndexRandom = getStLocIndex(second);
+                }
+
+                if (first.Calls(isAdoptionSpouse) && second.Branches(out System.Reflection.Emit.Label? branchLabel))
+                {
+                    if (localVariableIndexRandom == null)
+                    {
+                        Monitor.Log($"Could not find index of random in {nameof(NPC_marriageDuties_Transpiler)}", LogLevel.Warn);
+                        return;
+                    }
+
+                    System.Reflection.Emit.Label label = generator.DefineLabel();
+                    instructionsList[i - 1].labels.Add(label);
+                    instructionsList.InsertRange(i-1, new List<CodeInstruction>()
+                    {
+                        new CodeInstruction(OpCodes.Ldarg, 0),  // Load npc (this)
+                        new CodeInstruction(OpCodes.Ldloc, localVariableIndexRandom),  // Load random
+                        new CodeInstruction(OpCodes.Call, hookFunction),  // Call bool marriageDuties_AboutToGiveBirthDialogue_hook(npc, random)
+                        new CodeInstruction(OpCodes.Brfalse, label),  // If hook function returns false, branch to line after next return (Ret)
+                        new CodeInstruction(OpCodes.Ret)  // return
+                    });
+                    //instructionsList.InsertRange(i, new List<CodeInstruction>()
+                    //{
+                    //    new CodeInstruction(OpCodes.Call, configGayPregnancies),  // Get value from Config.GayPregnancies
+                    //    new CodeInstruction(OpCodes.Brtrue, branchLabel)  // Branch if value is true (skipping the isAdoptionSpouse dialogue)
+                    //});
+                    return;
+                }
+            }
+
+            // We only reach this if there was never a match
+            Monitor.Log($"Could not apply pregnant dialogue patch in {nameof(NPC_marriageDuties_Transpiler)}", LogLevel.Warn);
+        }
+
+        /// <summary>
+        /// Called by the marriageDuties transpiler if the NPC is soon to give birth (called before other dialogue checks)
+        /// </summary>
+        /// <param name="npc"></param>
+        /// <returns>true if marriageDuties should return after this function ends</returns>
+        public static bool marriageDuties_AboutToGiveBirthDialogue_hook(NPC npc, Random random)
+        {
+            try
+            {
+                Farmer farmer = npc.getSpouse();
+                if (farmer == null)
+                    return false;
+
+                if (npc.Gender != farmer.Gender)
+                    return false;
+
+                if (!Config.GayPregnancies)
+                    return false;
+
+                FarmHouse farmHouse = Game1.RequireLocation<FarmHouse>(farmer.homeLocation.Value);
+
+                if (npc.Gender != Gender.Female || Config.ImpregnatingFemmeNPC)
+                {
+                    // Honey, did you know you're pregnant? / We're pregnant
+                    npc.setTilePosition(farmHouse.getKitchenStandingSpot());
+                    if (!npc.spouseObstacleCheck(new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4446", true), farmHouse))
+                    {
+                        if (random.NextBool())
+                        {
+                            npc.currentMarriageDialogue.Clear();
+                        }
+
+                        npc.currentMarriageDialogue.Add(random.NextBool() ? new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4447", true, farmer.displayName) : new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4448", false, "%endearment"));
+                    }
+
+                    return true;
+                }
+
+                // I'm pregnant, isn't that great
+                npc.setTilePosition(farmHouse.getKitchenStandingSpot());
+                if (!npc.spouseObstacleCheck(random.NextBool() ? new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4442", false) : new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4443", false), farmHouse))
+                {
+                    if (random.NextBool())
+                    {
+                        npc.currentMarriageDialogue.Clear();
+                    }
+
+                    npc.currentMarriageDialogue.Add(random.NextBool() ? new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4444", false, farmer.displayName) : new MarriageDialogueReference("Strings\\StringsFromCSFiles", "NPC.cs.4445", false, "%endearment"));
+                }
+
+                return true;
+            }
+            catch (Exception e)
+            {
+                Monitor.Log($"Failed in {nameof(marriageDuties_AboutToGiveBirthDialogue_hook)}:\n{e}", LogLevel.Error);
+                return false;
+            }
+        }
+
+        public static object getStLocIndex(CodeInstruction code)
+        {
+            if (!code.IsStloc())
+                return null;
+            if (code.operand != null)
+                return code.operand;
+            if (code.opcode == OpCodes.Stloc_0) return 0;
+            if (code.opcode == OpCodes.Stloc_1) return 1;
+            if (code.opcode == OpCodes.Stloc_2) return 2;
+            if (code.opcode == OpCodes.Stloc_3) return 3;
+            return null;
         }
 
         public static bool NPC_engagementResponse_Prefix(NPC __instance, Farmer who, ref bool asRoommate)
@@ -613,7 +853,7 @@ namespace PolyamorySweetLove
         }
           */
 
-        public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, ref Farmer who, bool probe, Dictionary<string, string> ___dialogue, ref bool __result, ref string __state)
+            public static bool NPC_tryToReceiveActiveObject_Prefix(NPC __instance, ref Farmer who, bool probe, Dictionary<string, string> ___dialogue, ref bool __result, ref string __state)
         {
             try
             {
@@ -983,7 +1223,7 @@ namespace PolyamorySweetLove
 
 
                             //if (c.Equals(who.spouse) || c.Equals(roomie))
-                            if (ModEntry.GetSpouses(who, true).ContainsKey(__instance.Name))
+                            if (ModEntry.GetSpouses(who, false).ContainsKey(__instance.Name))
                             {
 
                                 {
@@ -1169,13 +1409,13 @@ namespace PolyamorySweetLove
             return true;
         }
 
-        public static void NPC_tryToReceiveActiveObject_Postfix(string __state)
+        public static void NPC_tryToReceiveActiveObject_Postfix(ref Farmer who, string __state)
         {
             try
             {
                 if (__state != null)
                 {
-                    Game1.player.spouse = __state;
+                    who.spouse = __state;
                 }
             }
             catch (Exception ex)
@@ -1250,6 +1490,18 @@ namespace PolyamorySweetLove
             catch (Exception ex)
             {
                 Monitor.Log($"Failed in {nameof(NPC_playSleepingAnimation_Postfix)}:\n{ex}", LogLevel.Error);
+            }
+        }
+
+        public static void NPC_setUpForOutdoorPatioActivity_Postfix(NPC __instance)
+        {
+            try
+            {
+                PatioSpouse = __instance;
+            }
+            catch (Exception ex)
+            {
+                Monitor.Log($"Failed in {nameof(NPC_setUpForOutdoorPatioActivity_Postfix)}:\n{ex}", LogLevel.Error);
             }
         }
 

--- a/PolyamorySweetLoveAPI.cs
+++ b/PolyamorySweetLoveAPI.cs
@@ -11,7 +11,7 @@ namespace PolyamorySweetLove
         {
             ModEntry.PlaceSpousesInFarmhouse(farmHouse);
         }
-        public Dictionary<string, NPC> GetSpouses(Farmer farmer, bool all = true)
+        public Dictionary<string, NPC> GetSpouses(Farmer farmer, bool all = false)
         {
             return ModEntry.GetSpouses(farmer, all);
         }


### PR DESCRIPTION
Overview of changes:
- PlaceSpousesInFarmhouse is no longer called. I didn't delete it yet though.
- Added patching to NPC.marriageDuties instead. This is largely with transpilers. I included comments of what the IL code looks like. (If you don't understand transpilers, I could potentially teach you if you'd like)
- Modified GetSpouses helper method. Passing all=false will now return all spouses, while all=true will include an engaged NPC if there is one.
- Spouses can naturally request more children if there are 2+ children again.
- Spouses should no longer overlap in the morning. They can still overlap if multiple spouses pathfind to the same spot though (normally observable when spouses come home after being out since they usually go to the kitchen spot)
- Spouses should no longer be sleeping in the morning in random spots (either fixed or very low chance).
- Spouses should no longer have duplicate morning dialogue.
- Engaged NPCs should no longer appear in the farmhouse before the wedding.
- Removed a couple random patches that didn't seem to be doing anything useful (haven't deleted their code yet).

Since merging your latest changes into my fork, I have not tested things at all. I tested my own changes with a personal build, but I didn't have anything since your "I hope these don't collide" commit.